### PR TITLE
Check that user can still view cart after login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'shoulda', '~> 3.5'
   gem 'shoulda-matchers', '~> 2.0'
   gem "factory_girl_rails", "~> 4.0"
+  gem "mocha"
  end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,10 +95,13 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     multi_json (1.11.2)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -199,6 +202,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   launchy
+  mocha
   pg (~> 0.15)
   pry-rails
   rails (= 4.2.5.1)

--- a/test/integration/visitor_can_register_and_login_test.rb
+++ b/test/integration/visitor_can_register_and_login_test.rb
@@ -33,4 +33,18 @@ class VisitorCanRegisterAndLoginTest < ActionDispatch::IntegrationTest
 
     assert page.has_content?("Logout")
   end
+
+  test "visitor adds stuff to cart and still sees it upon login" do
+    gif = create(:gif)
+    visit gif_path(gif)
+    click_button "Add to cart"
+
+    user = User.create(username: "Brock", password: "password")
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit 'cart'
+    assert_equal "/cart", current_path
+    assert page.has_content?(gif.title)
+    assert page.has_content?(gif.image)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require "rails/test_help"
 require "capybara/rails"
 require "minitest/pride"
+require 'mocha/mini_test'
 
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
Added test to authentication tests to ensure that a cart persists after a visitor
logs in.