### PR TITLE
Add individual admin order view

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,9 +4,9 @@ class Order < ActiveRecord::Base
   has_many :gifs, through: :order_gifs
 
   def order_status
-    if status == "completed"
+    if status.upcase == "completed".upcase
       "Order Complete on #{updated_at}"
-    elsif status == "cancelled"
+    elsif status.upcase == "cancelled".upcase
       "Order cancelled on #{updated_at}"
     else
       "In progress"

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,0 +1,37 @@
+<h1 class="text-center">admin_order_view_#<%= @order.id %></h1>
+​<div class="container">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Total Price</th>
+        <th>Created At</th>
+        <th>Updated At</th>
+        <th>Order Status</th>
+      </tr>
+    </thead>
+    <tbody>
+        <div id="gif-info">
+          <tr>
+            <td><%= @order.status %></td>
+            <td><%= number_to_currency(@order.total_price) %></td>
+            <td><%= @order.created_at %></td>
+            <td><%= @order.updated_at %></td>
+            <td><%= @order.order_status %></td>
+          </tr>
+        </div>
+    </tbody>
+  </table>
+</div>
+
+<div class="container">
+  <% @order.order_gifs.each do |order_gif| %>
+  <div class="col-md-7">
+    <div class="row product">
+      <div class="col-md-5 col-md-offset-0"><p><%= image_tag order_gif.gif.image, width: 200 %></p>
+      </div>
+      <h4><%= link_to order_gif.gif.title, gif_path(order_gif.gif) %></h4>
+      <h4>Quantity: <%= order_gif.quantity %></h4>
+    </div>
+  </div>
+  <% end %>

--- a/test/integration/admin_control_orders_dashboard_test.rb
+++ b/test/integration/admin_control_orders_dashboard_test.rb
@@ -15,7 +15,51 @@ class AdminControlOrdersDashboardTest < ActionDispatch::IntegrationTest
     assert page.has_link?(recent_order.id, admin_order_path(recent_order))
   end
 
-  test "admin filters orders by status type and transitions status" do
+  test "admin clicks link for individual order and views it" do
+    create_and_return_admin
+    create_multiple_orders(6)
+    recent_order = Order.last
 
+    visit admin_dashboard_path
+    click_link "View all orders"
+    assert page.has_link?(recent_order.id, admin_order_path(recent_order))
+    click_link(recent_order.id)
+
+    assert_equal admin_order_path(recent_order), current_path
+    recent_order.order_gifs.each do |order_gif|
+      assert page.has_link?(order_gif.gif.title)
+      assert page.has_css?("img[src='#{order_gif.gif.image}']")
+      assert page.has_content?(order_gif.quantity)
+      assert page.has_content?(order_gif.subtotal)
+    end
+
+    assert page.has_content? recent_order.status
+    assert page.has_content? recent_order.total_price
+    assert page.has_content? recent_order.created_at
+    assert page.has_content? recent_order.order_status
+    assert page.has_content? recent_order.updated_at
+  end
+
+  test "admin filters orders by status type and transitions status" do
+    create_and_return_admin
+    create_multiple_orders(10)
+    recent_order = Order.last
+
+    visit admin_orders_path
+    assert page.has_content? "Ordered: 10"
+    within page.all("tr")[3] do
+      click_link "Mark As Paid"
+    end
+
+    assert page.has_content? "Ordered: 9"
+    assert page.has_content? "Paid: 1"
+
+    within page.all("tr")[5] do
+      click_link "Cancel"
+    end
+    save_and_open_page
+    refute page.has_content? "Ordered: 9"
+    assert page.has_content? "Cancelled: 1"
+    assert page.has_content? "Paid: 1"
   end
 end


### PR DESCRIPTION
Finished testing the admin order view. Individual order view for admin now returns a view similar to the user's own view. Fixed order_status method to be case-insensitive. Next step will be adding status to an enum and making a default status (Ordered).