### PR TITLE
Change order status to enums model, implement predicate methods

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -8,8 +8,8 @@ class Admin::OrdersController < Admin::BaseController
 
   def update
     @order = Order.find(params[:id])
-    @order.update(status: params[:status])
-    flash[:success] = "You have successfully updated Order#{@order.id} as #{params[:status]}"
+    @order.update(status: params[:status].to_i)
+    flash[:success] = "You have successfully updated Order#{@order.id} as #{@order.status}"
     redirect_to admin_orders_path
   end
 

--- a/app/grids/orders_grid.rb
+++ b/app/grids/orders_grid.rb
@@ -24,18 +24,18 @@ class OrdersGrid
   column(:status)
   column(:total_price)
   column(:cancel, :html => true) do |record|
-    if record.status == "Ordered" || "Paid"
-      link_to "Cancel", admin_order_path(record, status: "Cancelled"), method: :patch
+    if record.ordered? || record.paid?
+      link_to "Cancel", admin_order_path(record, status: 3), method: :patch
     end
   end
   column(:mark_as_paid, :html => true) do |record|
-    if record.status == "Ordered"
-      link_to "Mark As Paid", admin_order_path(record, status: "Paid"), method: :patch
+    if record.ordered?
+      link_to "Mark As Paid", admin_order_path(record, status: 1), method: :patch
     end
   end
   column(:mark_as_completed, html: true) do |record|
-    if record.status == "Paid"
-      link_to "Mark As Completed", admin_order_path(record, status: "Completed"), method: :patch
+    if record.paid?
+      link_to "Mark As Completed", admin_order_path(record, status: 2), method: :patch
     end
   end
 end

--- a/app/models/gif.rb
+++ b/app/models/gif.rb
@@ -3,10 +3,10 @@ class Gif < ActiveRecord::Base
   validates :description, presence: true
   validates :price, presence: true, numericality: { greater_than: 0 }
   validates :image, presence: true
-  has_many :tags, through: :gif_tags
-  has_many :orders, through: :order_gifs
   has_many :gif_tags
+  has_many :tags, through: :gif_tags
   has_many :order_gifs
+  has_many :orders, through: :order_gifs
 
   def format_price
     price.to_f / 100

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,10 +5,12 @@ class Order < ActiveRecord::Base
   has_many :order_gifs
   has_many :gifs, through: :order_gifs
 
+  enum status: %w(ordered paid completed cancelled)
+
   def order_status
-    if status.upcase == "completed".upcase
+    if completed?
       "Order Complete on #{updated_at}"
-    elsif status.upcase == "cancelled".upcase
+    elsif cancelled?
       "Order cancelled on #{updated_at}"
     else
       "In progress"
@@ -16,6 +18,9 @@ class Order < ActiveRecord::Base
   end
 
   def self.status_breakdown
-    group(:status).order("count_status desc").count(:status)
+    grouped = group(:status).order("count_status desc").count(:status)
+    changed = grouped.map do | k, v |
+      [statuses.key(k), v]
+    end.to_h
   end
 end

--- a/app/models/order_processor.rb
+++ b/app/models/order_processor.rb
@@ -10,7 +10,7 @@ class OrderProcessor
   end
 
   def process_order
-    order = user.orders.create(total_price: cart.total_price, status: "Pending")
+    order = user.orders.create(total_price: cart.total_price, status: 0)
     cart_gifs.each do | cart_gif |
       order.order_gifs.create(gif_id: cart_gif.id, quantity: cart_gif.quantity, subtotal: cart_gif.subtotal)
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
 class Tag < ActiveRecord::Base
-  has_many :gifs, through: :gif_tags
   has_many :gif_tags
+  has_many :gifs, through: :gif_tags
 end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -5,9 +5,8 @@
       <tr><th>Order Statuses</th></tr>
       <% if @orders %>
         <% @orders.status_breakdown.each do |status, amount| %>
-          <% next if status.nil? %>
           <tr>
-            <td><%= "#{status}: #{amount}" %></td>
+            <td><%= "#{status.capitalize}: #{amount}" %></td>
           </tr>
         <% end %>
       <% end %>

--- a/db/migrate/20160305170016_add_status_to_orders.rb
+++ b/db/migrate/20160305170016_add_status_to_orders.rb
@@ -1,5 +1,5 @@
 class AddStatusToOrders < ActiveRecord::Migration
   def change
-    add_column :orders, :status, :string
+    add_column :orders, :status, :integer, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,9 +50,9 @@ ActiveRecord::Schema.define(version: 20160305222929) do
 
   create_table "orders", force: :cascade do |t|
     t.integer  "user_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.string   "status"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.integer  "status",      default: 0
     t.integer  "total_price"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,12 +16,12 @@ end
   subtotal = Random.new.rand(1..10)
   user = User.create(username: "string", password: "password")
   gif = Gif.all.shuffle.first
-  order = user.orders.create(total_price: 3*subtotal, status: "Ordered")
-  order.order_gifs.create(
+  order = user.orders.create!(total_price: 3*subtotal)
+  order.order_gifs.create!(
     gif_id: gif.id, quantity: 1, subtotal: subtotal
   )
   gif = Gif.all.shuffle.first
-  order.order_gifs.create(
+  order.order_gifs.create!(
     gif_id: gif.id, quantity: 2, subtotal: subtotal*2
   )
 end

--- a/test/factories/orders.rb
+++ b/test/factories/orders.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :order do
     total_price 1000
-    status "Pending"
   end
 end

--- a/test/integration/admin_control_orders_dashboard_test.rb
+++ b/test/integration/admin_control_orders_dashboard_test.rb
@@ -47,14 +47,14 @@ class AdminControlOrdersDashboardTest < ActionDispatch::IntegrationTest
 
     visit admin_orders_path
     assert page.has_content? "Ordered: 10"
-    within page.all("tr")[3] do
+    within "tr:nth-child(3)" do
       click_link "Mark As Paid"
     end
 
     assert page.has_content? "Ordered: 9"
     assert page.has_content? "Paid: 1"
 
-    within page.all("tr")[5] do
+    within "tr:nth-child(4)" do
       click_link "Cancel"
     end
 

--- a/test/integration/authenticated_user_security_test.rb
+++ b/test/integration/authenticated_user_security_test.rb
@@ -4,14 +4,14 @@ class AuthenticatedUserSecuirtyTest < ActionDispatch::IntegrationTest
   test "user cannot view other user's info" do
     user1 = create(:user)
     gif1 = create(:gif)
-    order1 = user1.orders.create(total_price: 100, status: "Pending")
+    order1 = user1.orders.create(total_price: 100)
     order_gif1 = order1.order_gifs.create(
       gif_id: gif1.id, quantity: 1, subtotal: 100
     )
 
     user2 = create(:user)
     gif2 = create(:gif)
-    order2 = user2.orders.create(total_price: 100, status: "Pending")
+    order2 = user2.orders.create(total_price: 100)
     order_gif2 = order2.order_gifs.create(
       gif_id: gif2.id, quantity: 1, subtotal: 100
     )

--- a/test/integration/unauthenticated_user_security_test.rb
+++ b/test/integration/unauthenticated_user_security_test.rb
@@ -4,7 +4,7 @@ class UnauthenticatedUserSecurityTest < ActionDispatch::IntegrationTest
   test "visitor cannot see other users' orders" do
     user1 = create(:user)
     gif1 = create(:gif)
-    order1 = user1.orders.create(total_price: 100, status: "Pending")
+    order1 = user1.orders.create(total_price: 100)
     order_gif1 = order1.order_gifs.create(
       gif_id: gif1.id, quantity: 1, subtotal: 100
     )

--- a/test/integration/user_can_view_a_past_order_test.rb
+++ b/test/integration/user_can_view_a_past_order_test.rb
@@ -4,7 +4,7 @@ class UserCanViewAPastOrderTest < ActionDispatch::IntegrationTest
   test "user sees details about their order" do
     user = User.create(username: "Jade", password: "passsword")
     gif = create(:gif)
-    order = user.orders.create(total_price: 100, status: "Pending")
+    order = user.orders.create(total_price: 100)
     order_gif = order.order_gifs.create(
       gif_id: gif.id, quantity: 1, subtotal: 100
     )

--- a/test/integration/user_can_view_a_retired_gif_test.rb
+++ b/test/integration/user_can_view_a_retired_gif_test.rb
@@ -10,7 +10,7 @@ class UserCanViewARetiredGifTest < ActionDispatch::IntegrationTest
                      retired: true
     )
     ApplicationController.any_instance.stubs(:current_user).returns(user)
-    order = user.orders.create(total_price: 100, status: "completed")
+    order = user.orders.create(total_price: 100, status: 2)
     order_gif = order.order_gifs.create(gif_id: gif.id, quantity: 1, subtotal: 100)
 
     visit order_path(order.id)

--- a/test/integration/user_can_view_all_past_orders_test.rb
+++ b/test/integration/user_can_view_all_past_orders_test.rb
@@ -5,8 +5,8 @@ class UserCanViewAllPastOrdersTest < ActionDispatch::IntegrationTest
     user = User.create(username: "Jonas", password: "password")
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 
-    order1 = user.orders.create(status: "pending", total_price: 10000)
-    order2 = user.orders.create(status: "pending", total_price: 10000)
+    order1 = user.orders.create(total_price: 10000)
+    order2 = user.orders.create(total_price: 10000)
 
     visit "/orders"
 

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -11,9 +11,9 @@ class OrderTest < ActiveSupport::TestCase
 
   test "order status returns correct order status" do
     user = User.create(username: "Jade", password: "passsword")
-    order1 = user.orders.create(status: "completed")
-    order2 = user.orders.create(status: "cancelled")
-    order3 = user.orders.create(status: "pending")
+    order1 = user.orders.create(status: 2)
+    order2 = user.orders.create(status: 3)
+    order3 = user.orders.create(status: 0)
 
     assert_equal "Order Complete on #{order1.updated_at}", order1.order_status
     assert_equal "Order cancelled on #{order2.updated_at}", order2.order_status

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,14 +46,17 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+
+
   def create_multiple_orders(num)
     num.times do
       user = create(:user)
       gif = create(:gif)
-      order = user.orders.create(total_price: 100, status: "Ordered")
-      order.order_gifs.create(
+      OrderGif.create(
         gif_id: gif.id, quantity: 1, subtotal: 100
       )
+      order = user.orders.create!(total_price: 100, status: 0)
+
       gif = create(:gif)
       order.order_gifs.create(
         gif_id: gif.id, quantity: 2, subtotal: 100


### PR DESCRIPTION
We wanted to change our order status attribute to have a default behavior, and to
use enums for consistency and ease.Was a seemingly simple refactor, but involved
a migration to create the default behavior. Now all 4 order statuses are defined
in the enum model, with "ordered" mapping to the default value.

Tests were refactored to remove creation with strings
and you will want to note that in creating any future orders you need to specify
the number corresponding to the status you would like. However, this does let
us simply ask if something is .ordered? or cancelled? Hence, I also had to
refactor a couple of methods and views.

Additionally, the other issues in this waffle card were changed, including
switching the order of has_ and has_through attributes on classes and adding
better Capybara CSS matchers on a couple of tests.